### PR TITLE
Classroom correct answer moves forward

### DIFF
--- a/app/src/main/java/swen_anigans/mathematicfanatic/ClassroomActivity.java
+++ b/app/src/main/java/swen_anigans/mathematicfanatic/ClassroomActivity.java
@@ -75,16 +75,7 @@ public class ClassroomActivity extends AppCompatActivity {
     }
 
     public void nextPage(View view) {
-
-        saveAnswer();
-        TextView answerInput = (TextView) findViewById(R.id.editClassroomAnswer);
-        answerInput.setText("");
-        pageNumber += 1;
-        if (pageNumber > totalPages) {
-            finishedQuestions();
-        } else {
-            renderPage();
-        }
+        checkAnswer(view);
     }
 
     public void saveAnswer(){
@@ -144,6 +135,7 @@ public class ClassroomActivity extends AppCompatActivity {
         }else if(questionContent.questions.get(pageNumber - 1).checkAnswer()){
             text = "Correct!";
             ToastLib.success(this, text, Typeface.create("Helvetica", 0));
+            this.goToNextPage();
         }else{
             // Custom incorrect toast message
             text = "Try Again, You can do it!";
@@ -159,6 +151,18 @@ public class ClassroomActivity extends AppCompatActivity {
 
             message.show();
         }
+    }
 
+    private void goToNextPage()
+    {
+        saveAnswer();
+        TextView answerInput = (TextView) findViewById(R.id.editClassroomAnswer);
+        answerInput.setText("");
+        pageNumber += 1;
+        if (pageNumber > totalPages) {
+            finishedQuestions();
+        } else {
+            renderPage();
+        }
     }
 }

--- a/app/src/main/java/swen_anigans/mathematicfanatic/ClassroomActivity.java
+++ b/app/src/main/java/swen_anigans/mathematicfanatic/ClassroomActivity.java
@@ -8,8 +8,9 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.View;
-import android.widget.Button;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -17,7 +18,7 @@ import com.droidbyme.toastlib.ToastEnum;
 import com.droidbyme.toastlib.ToastLib;
 
 
-public class ClassroomActivity extends AppCompatActivity {
+public class ClassroomActivity extends AppCompatActivity implements View.OnClickListener {
 
     private int pageNumber = 1;
     private int totalPages = 20;
@@ -39,6 +40,10 @@ public class ClassroomActivity extends AppCompatActivity {
 
         questionContent = DataManager.getInstance().questionsContent;
 
+        // add the action listener onto the edit text
+        EditText answer = (EditText) findViewById(R.id.editClassroomAnswer);
+        answer.setOnClickListener(this);
+
         renderPage();
     }
 
@@ -52,14 +57,6 @@ public class ClassroomActivity extends AppCompatActivity {
         if (question.submittedAnswer != 0){
             EditText editQuizAnswer = (EditText) findViewById(R.id.editClassroomAnswer);
             editQuizAnswer.setText(Integer.toString(question.submittedAnswer));
-        }
-
-        Button PreviousButton = (Button) findViewById(R.id.prevButton);
-        if (pageNumber == 1) {
-            //Hides the back button on the first page
-            PreviousButton.setVisibility(View.INVISIBLE);
-        }else {
-            PreviousButton.setVisibility(View.VISIBLE);
         }
 
         TextView quizPagesComplete = (TextView) findViewById(R.id.quizPagesComplete);
@@ -99,9 +96,7 @@ public class ClassroomActivity extends AppCompatActivity {
     }
 
     public void finishedQuestions(){
-        int[] items = { R.id.prevButton,
-                        R.id.nextButton,
-                        R.id.checkButton,
+        int[] items = { R.id.checkButton,
                         R.id.editClassroomAnswer,
                         R.id.quizPagesComplete,
                         R.id.goToHelpButton
@@ -153,6 +148,8 @@ public class ClassroomActivity extends AppCompatActivity {
         }
     }
 
+    //region private functions
+
     private void goToNextPage()
     {
         saveAnswer();
@@ -165,4 +162,33 @@ public class ClassroomActivity extends AppCompatActivity {
             renderPage();
         }
     }
+
+    //endregion
+
+    //region OnClick Interface
+
+    @Override
+    public void onClick(View view)
+    {
+        EditText editText = (EditText) findViewById(R.id.editClassroomAnswer);
+        editText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+
+            @Override
+            public boolean onEditorAction(TextView view, int actionId, KeyEvent event) {
+                int result = actionId & EditorInfo.IME_MASK_ACTION;
+                switch(result)
+                {
+                    case EditorInfo.IME_ACTION_NEXT:
+                        if(1 == 1)
+                        {
+                            checkAnswer(view);
+                        }
+                        return true;
+                }
+                return false;
+            }
+        });
+    }
+
+    //endregion
 }

--- a/app/src/main/res/layout/activity_classroom.xml
+++ b/app/src/main/res/layout/activity_classroom.xml
@@ -120,6 +120,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:inputType="number"
+        android:imeOptions="actionNone"
         android:ems="10"
         android:id="@+id/editClassroomAnswer"
         android:textAlignment="center"

--- a/app/src/main/res/layout/activity_classroom.xml
+++ b/app/src/main/res/layout/activity_classroom.xml
@@ -94,7 +94,7 @@
         android:layout_width="@dimen/long_button_width"
         android:layout_height="wrap_content"
         android:inputType="number"
-        android:imeOptions="actionNone"
+        android:imeOptions="actionNext"
         android:textSize="35sp"
         android:ems="10"
         android:id="@+id/editClassroomAnswer"

--- a/app/src/main/res/layout/activity_classroom.xml
+++ b/app/src/main/res/layout/activity_classroom.xml
@@ -45,7 +45,7 @@
         android:textSize="65sp"
         android:text="Large Text"
         android:id="@+id/classroomQuestion"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginTop="8dp"
         android:layout_below="@+id/goToHelpButton"
         android:layout_centerHorizontal="true" />
 
@@ -59,7 +59,7 @@
         android:onClick="checkAnswer"
         android:layout_marginStart="@dimen/big_button_margin"
         android:theme="@style/NormalButton"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginTop="8dp"
         android:paddingStart="@dimen/big_button_horizontal_padding"
         android:paddingEnd="@dimen/big_button_horizontal_padding"/>
 
@@ -95,13 +95,13 @@
         android:layout_height="wrap_content"
         android:inputType="number"
         android:imeOptions="actionNext"
-        android:textSize="35sp"
+        android:textSize="25sp"
         android:ems="10"
         android:id="@+id/editClassroomAnswer"
         android:textAlignment="center"
         android:layout_marginEnd="@dimen/activity_horizontal_margin"
         android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginTop="8dp"
         android:layout_below="@+id/classroomQuestion"
         android:layout_centerHorizontal="true" />
 

--- a/app/src/main/res/layout/activity_classroom.xml
+++ b/app/src/main/res/layout/activity_classroom.xml
@@ -45,7 +45,7 @@
         android:textSize="65sp"
         android:text="Large Text"
         android:id="@+id/classroomQuestion"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="4dp"
         android:layout_below="@+id/goToHelpButton"
         android:layout_centerHorizontal="true" />
 
@@ -95,7 +95,7 @@
         android:layout_height="wrap_content"
         android:inputType="number"
         android:imeOptions="actionNext"
-        android:textSize="25sp"
+        android:textSize="30sp"
         android:ems="10"
         android:id="@+id/editClassroomAnswer"
         android:textAlignment="center"

--- a/app/src/main/res/layout/activity_classroom.xml
+++ b/app/src/main/res/layout/activity_classroom.xml
@@ -42,7 +42,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="60sp"
+        android:textSize="65sp"
         android:text="Large Text"
         android:id="@+id/classroomQuestion"
         android:layout_marginTop="@dimen/activity_vertical_margin"
@@ -58,36 +58,10 @@
         android:layout_below="@+id/editClassroomAnswer"
         android:onClick="checkAnswer"
         android:layout_marginStart="@dimen/big_button_margin"
-        android:theme="@style/NormalButton" />
-
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="&gt;"
-        android:id="@+id/nextButton"
-        android:textSize="40sp"
-        android:onClick="nextPage"
-        android:layout_alignEnd="@+id/quizPagesComplete"
-        android:layout_below="@+id/checkButton"
-        android:paddingEnd="@dimen/big_button_horizontal_padding"
+        android:theme="@style/NormalButton"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         android:paddingStart="@dimen/big_button_horizontal_padding"
-        android:layout_alignParentBottom="true"
-        android:layout_marginStart="@dimen/big_button_margin"
-        android:theme="@style/NormalButton"/>
-
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="&lt;"
-        android:id="@+id/prevButton"
-        android:textSize="40sp"
-        android:onClick="previousPage"
-        android:layout_alignStart="@+id/goToHelpButton"
-        android:layout_below="@+id/checkButton"
-        android:paddingEnd="@dimen/big_button_horizontal_padding"
-        android:paddingStart="@dimen/big_button_horizontal_padding"
-        android:layout_alignParentBottom="true"
-        android:theme="@style/NormalButton"/>
+        android:paddingEnd="@dimen/big_button_horizontal_padding"/>
 
     <Button
         android:id="@+id/goToHelpButton"
@@ -117,13 +91,16 @@
         android:theme="@style/NormalButton"/>
 
     <EditText
-        android:layout_width="wrap_content"
+        android:layout_width="@dimen/long_button_width"
         android:layout_height="wrap_content"
         android:inputType="number"
         android:imeOptions="actionNone"
+        android:textSize="35sp"
         android:ems="10"
         android:id="@+id/editClassroomAnswer"
         android:textAlignment="center"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:layout_marginTop="@dimen/activity_vertical_margin"
         android:layout_below="@+id/classroomQuestion"
         android:layout_centerHorizontal="true" />


### PR DESCRIPTION
- Huge shout out to @matthewGallagher for figuring out the "next" button on the number input!!
- Changed it so that the classroom can only go forward.
- Changed it so the classroom only goes forward when it is a correct answer
- Removed the back and forward buttons, instead we have the check and "next" button both check if it is right and move forward.

# Minimalist Design
![screenshot_2016-11-28-17-02-09](https://cloud.githubusercontent.com/assets/11997261/20688310/51307ce4-b58e-11e6-9383-b02a86437060.png)
![screenshot_2016-11-28-17-00-42](https://cloud.githubusercontent.com/assets/11997261/20688316/595ad7ca-b58e-11e6-9a63-4ee121d00f90.png)
![screenshot_2016-11-28-17-14-12](https://cloud.githubusercontent.com/assets/11997261/20688341/6d98ef92-b58e-11e6-8a24-526392911185.png)
![screenshot_2016-11-28-17-13-09](https://cloud.githubusercontent.com/assets/11997261/20688323/5e83473c-b58e-11e6-88db-62843bc7c431.png)
